### PR TITLE
Stop using {{.Os}} and {{.Arch}} tmpl vals

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,13 +6,11 @@ builds:
   - id: "linux"
     env:
       - CGO_ENABLED=0
-      - OS={{ .Os }}
-      - ARCH={{ .Arch }}
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X "internal/version.Platform={{ .Env.OS }}/{{ .Env.ARCH }}" -X "github.com/slosive/sloscribe/internal/version.Version={{ .Version }}" -X "github.com/slosive/sloscribe/internal/version.Commit={{ .Commit }}" -X "github.com/slosive/sloscribe/internal/version.Date={{ .Date }}"'
+      - '-s -w -X "internal/version.Platform=linux/unknown" -X "github.com/slosive/sloscribe/internal/version.Version={{ .Version }}" -X "github.com/slosive/sloscribe/internal/version.Commit={{ .Commit }}" -X "github.com/slosive/sloscribe/internal/version.Date={{ .Date }}"'
     binary: "{{ .ProjectName }}"
     goos:
       - linux
@@ -23,13 +21,11 @@ builds:
   - id: "darwin"
     env:
       - CGO_ENABLED=0
-      - OS={{ .Os }}
-      - ARCH={{ .Arch }}
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X "github.com/slosive/sloscribe/internal/version.Platform={{ .Env.OS }}/{{ .Env.ARCH }}" -X "github.com/slosive/sloscribe/internal/version.Version={{ .Version }}" -X "github.com/slosive/sloscribe/internal/version.Commit={{.Commit}}" -X "github.com/slosive/sloscribe/internal/version.Date={{ .Date }}"'
+      - '-s -w -X "github.com/slosive/sloscribe/internal/version.Platform=darwin/unknown" -X "github.com/slosive/sloscribe/internal/version.Version={{ .Version }}" -X "github.com/slosive/sloscribe/internal/version.Commit={{.Commit}}" -X "github.com/slosive/sloscribe/internal/version.Date={{ .Date }}"'
     binary: "{{ .ProjectName }}"
     goos:
       - darwin
@@ -54,9 +50,6 @@ archives:
 kos:
   - working_dir: .
     id: "linux"
-    env:
-      - OS=linux
-      - ARCH=unknown
     build: "linux"
     base_image: gcr.io/distroless/base:nonroot
     labels:


### PR DESCRIPTION
Stops using the template values during build since KO doesn't have access to them.

<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/slotalk/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 🧪 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- StackOverflow answer
- Related pull requests/issues from other repositories
-->


