### PR TITLE
Fix regression error on the sloth parser

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -65,7 +65,7 @@ func specInitCmd(common *commonoptions.Options) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := logging.LoggerFromContext(cmd.Context())
-			logger.Info("Parsing source code for slo definitions",
+			logger.Info("Parsing source code for SLO definitions ⚙️",
 				"directories", opts.IncludedDirs,
 				"source", opts.Source,
 			)
@@ -88,7 +88,7 @@ func specInitCmd(common *commonoptions.Options) *cobra.Command {
 				return err
 			}
 
-			logger.Info("Source code was parsed")
+			logger.Info("Source code was parsed ✅")
 
 			// check if the user has selected a target service to output
 			selectedServices := services
@@ -109,19 +109,35 @@ func specInitCmd(common *commonoptions.Options) *cobra.Command {
 
 			// Only print to file if the user has selected the to-file option
 			if opts.ToFile {
-				logger.Info("Generating specifications files in output directory.", "directory", generate.DefaultServiceDefinitionDir)
-				if err := generate.WriteSpecifications(nil, []byte(header), selectedServices, true, ".", outputKubernetes, opts.Formats...); err != nil {
-					logger.Error(err, "Generating specification file error")
-					return err
+				logger.Info("Generating specifications files in output directory ✍🏿", "directory", generate.DefaultServiceDefinitionDir)
+				if outputKubernetes {
+					if err := generate.WriteK8Specifications(nil, []byte(header), selectedServices, true, ".", opts.Formats...); err != nil {
+						logger.Error(err, "Generating specification file error")
+						return err
+					}
+				} else {
+					if err := generate.WriteSpecifications(nil, []byte(header), selectedServices, true, ".", opts.Formats...); err != nil {
+						logger.Error(err, "Generating specification file error")
+						return err
+					}
 				}
 				return nil
 			}
 
-			logger.Info("Printing result specification to stdout.")
+			logger.Info("Printing result specification to stdout ✍🏿")
 			writer := cmd.OutOrStdout()
-			if err := generate.WriteSpecifications(writer, []byte(header), selectedServices, false, "", outputKubernetes, opts.Formats...); err != nil {
-				logger.Error(err, "Writing specification to stdout error")
-				return err
+
+			// Print the specification(s) to stout or file
+			if outputKubernetes {
+				if err := generate.WriteK8Specifications(writer, []byte(header), selectedServices, false, "", opts.Formats...); err != nil {
+					logger.Error(err, "Writing specification to stdout error")
+					return err
+				}
+			} else {
+				if err := generate.WriteSpecifications(writer, []byte(header), selectedServices, false, "", opts.Formats...); err != nil {
+					logger.Error(err, "Writing specification to stdout error")
+					return err
+				}
 			}
 			return nil
 		},

--- a/internal/generate/README.md
+++ b/internal/generate/README.md
@@ -13,7 +13,8 @@ Package generate contains utilities to generate data from a given specification
 - [Constants](<#constants>)
 - [Variables](<#variables>)
 - [func IsValidOutputFormat\(format string\) bool](<#IsValidOutputFormat>)
-- [func WriteSpecifications\(writer io.Writer, header \[\]byte, specs map\[string\]any, toFile bool, outputDirectory string, kubernetes bool, formats ...string\) error](<#WriteSpecifications>)
+- [func WriteK8Specifications\(writer io.Writer, header \[\]byte, specs map\[string\]any, toFile bool, outputDirectory string, formats ...string\) error](<#WriteK8Specifications>)
+- [func WriteSpecifications\(writer io.Writer, header \[\]byte, specs map\[string\]any, toFile bool, outputDirectory string, formats ...string\) error](<#WriteSpecifications>)
 
 
 ## Constants
@@ -41,11 +42,20 @@ func IsValidOutputFormat(format string) bool
 
 
 
-<a name="WriteSpecifications"></a>
-## func [WriteSpecifications](<https://github.com/slosive/sloscribe/blob/main/internal/generate/generate.go#L34>)
+<a name="WriteK8Specifications"></a>
+## func [WriteK8Specifications](<https://github.com/slosive/sloscribe/blob/main/internal/generate/generate.go#L34>)
 
 ```go
-func WriteSpecifications(writer io.Writer, header []byte, specs map[string]any, toFile bool, outputDirectory string, kubernetes bool, formats ...string) error
+func WriteK8Specifications(writer io.Writer, header []byte, specs map[string]any, toFile bool, outputDirectory string, formats ...string) error
+```
+
+WriteK8Specifications write the k8s service spec bytes to a specific writer, stdout or file
+
+<a name="WriteSpecifications"></a>
+## func [WriteSpecifications](<https://github.com/slosive/sloscribe/blob/main/internal/generate/generate.go#L77>)
+
+```go
+func WriteSpecifications(writer io.Writer, header []byte, specs map[string]any, toFile bool, outputDirectory string, formats ...string) error
 ```
 
 WriteSpecifications write the service spec bytes to a specific writer, stdout or file

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -102,7 +102,7 @@ version: prometheus/v1
 service: app1
 `
 		var w = bytes.NewBuffer([]byte{})
-		require.NoError(t, WriteSpecifications(w, nil, specifications, false, "", false, "yaml"))
+		require.NoError(t, WriteSpecifications(w, nil, specifications, false, "", "yaml"))
 		if expected != w.String() && expected1 != w.String() {
 			t.Errorf("unexpected error when checking results")
 		}
@@ -135,7 +135,7 @@ service: app1
 		}
 
 		var w = bytes.NewBuffer([]byte{})
-		require.ErrorIs(t, WriteSpecifications(w, nil, specifications, false, "", false, "toml"), ErrUnsupportedFormat)
+		require.ErrorIs(t, WriteSpecifications(w, nil, specifications, false, "", "toml"), ErrUnsupportedFormat)
 	})
 }
 

--- a/internal/parser/specification/sloth/language/golang/README.md
+++ b/internal/parser/specification/sloth/language/golang/README.md
@@ -13,7 +13,7 @@ import "github.com/slosive/sloscribe/internal/parser/specification/sloth/languag
 
 
 <a name="Options"></a>
-## type [Options](<https://github.com/slosive/sloscribe/blob/main/internal/parser/specification/sloth/language/golang/parser.go#L32-L38>)
+## type [Options](<https://github.com/slosive/sloscribe/blob/main/internal/parser/specification/sloth/language/golang/parser.go#L33-L39>)
 
 Options contains the configuration options available to the Parser
 
@@ -28,7 +28,7 @@ type Options struct {
 ```
 
 <a name="NewOptions"></a>
-### func [NewOptions](<https://github.com/slosive/sloscribe/blob/main/internal/parser/specification/sloth/language/golang/parser.go#L40>)
+### func [NewOptions](<https://github.com/slosive/sloscribe/blob/main/internal/parser/specification/sloth/language/golang/parser.go#L41>)
 
 ```go
 func NewOptions() *Options

--- a/internal/parser/specification/sloth/language/golang/parser_test.go
+++ b/internal/parser/specification/sloth/language/golang/parser_test.go
@@ -138,7 +138,7 @@ func TestParseAnnotations(t *testing.T) {
 		}, (parser.specs["foobar"].(*sloth.Spec)).SLOs[0])
 	})
 
-	t.Run("Successfully parse sloth service if service name is defined after slo definition", func(t *testing.T) {
+	t.Run("Successfully parse sloth service if service name is defined after SLO definition", func(t *testing.T) {
 		parser := NewParser(nil)
 		comments := []*ast.CommentGroup{
 			{List: []*ast.Comment{
@@ -166,7 +166,7 @@ func TestParseAnnotations(t *testing.T) {
 			{
 				Version: sloth.Version,
 				Service: "foobar",
-				Labels:  nil,
+				Labels:  make(map[string]string),
 				SLOs: []sloth.SLO{
 					{
 						Name:        "availability",
@@ -205,7 +205,7 @@ func TestParseAnnotations(t *testing.T) {
 		}
 	})
 
-	t.Run("Successfully parse multiple Sloth services, should return 3 specifications", func(t *testing.T) {
+	t.Run("Successfully parse multiple Sloth services with single SLO defined, should return 3 specifications", func(t *testing.T) {
 		parser := NewParser(nil)
 		comments := []*ast.CommentGroup{
 			{List: []*ast.Comment{
@@ -364,6 +364,276 @@ func TestParseAnnotations(t *testing.T) {
 		}
 	})
 
+	t.Run("Successfully parse multiple Sloth services with multiple SLOs defined, should return 3 specifications", func(t *testing.T) {
+		parser := NewParser(nil)
+		comments := []*ast.CommentGroup{
+			{List: []*ast.Comment{
+				{
+					Text: `@sloth service foobar`,
+				},
+				{
+					Text: `@sloth.slo name availability`,
+				},
+				{
+					Text: `@sloth.slo description availability SLO for foobar service`,
+				},
+				{
+					Text: `@sloth.slo objective 95.0`,
+				},
+			}},
+			{List: []*ast.Comment{
+				{
+					Text: `@sloth.slo name correctness`,
+				},
+				{
+					Text: `@sloth.slo description correctness SLO for foobar service`,
+				},
+				{
+					Text: `@sloth.slo objective 55.0`,
+				},
+			}},
+			{List: []*ast.Comment{
+				{
+					Text: `@sloth service foo`,
+				},
+				{
+					Text: `@sloth.slo name availability`,
+				},
+				{
+					Text: `@sloth.slo description availability SLO for foo service`,
+				},
+				{
+					Text: `@sloth.slo objective 95.0`,
+				},
+			}},
+			{List: []*ast.Comment{
+				{
+					Text: `@sloth.slo name correctness`,
+				},
+				{
+					Text: `@sloth.slo description correctness SLO for foo service`,
+				},
+				{
+					Text: `@sloth.slo objective 85.0`,
+				},
+			}},
+			{List: []*ast.Comment{
+				{
+					Text: `@sloth.slo name freshness`,
+				},
+				{
+					Text: `@sloth.slo description freshness SLO for foo service`,
+				},
+				{
+					Text: `@sloth.slo objective 99.999`,
+				},
+			}},
+			{List: []*ast.Comment{
+				{
+					Text: `@sloth service bar`,
+				},
+				{
+					Text: `@sloth.slo name availability`,
+				},
+				{
+					Text: `@sloth.slo description availability SLO for bar service`,
+				},
+				{
+					Text: `@sloth.slo objective 95.0`,
+				},
+			}},
+		}
+		require.NoError(t, parser.parseSlothAnnotations(comments...))
+		require.Len(t, parser.specs, 3)
+		resultSpec := parser.specs
+
+		expected := []*sloth.Spec{
+			{
+				Version: sloth.Version,
+				Service: "foo",
+				Labels:  make(map[string]string),
+				SLOs: []sloth.SLO{
+					{
+						Name:        "availability",
+						Description: "availability SLO for foo service",
+						Objective:   95.0,
+						Labels:      make(map[string]string),
+						SLI: sloth.SLI{
+							Raw:    nil,
+							Events: nil,
+							Plugin: nil,
+						},
+						Alerting: sloth.Alerting{
+							Name:        "",
+							Labels:      nil,
+							Annotations: nil,
+							PageAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+							TicketAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+						},
+					},
+					{
+						Name:        "correctness",
+						Description: "correctness SLO for foo service",
+						Objective:   85.0,
+						Labels:      make(map[string]string),
+						SLI: sloth.SLI{
+							Raw:    nil,
+							Events: nil,
+							Plugin: nil,
+						},
+						Alerting: sloth.Alerting{
+							Name:        "",
+							Labels:      nil,
+							Annotations: nil,
+							PageAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+							TicketAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+						},
+					},
+					{
+						Name:        "freshness",
+						Description: "freshness SLO for foo service",
+						Objective:   99.999,
+						Labels:      make(map[string]string),
+						SLI: sloth.SLI{
+							Raw:    nil,
+							Events: nil,
+							Plugin: nil,
+						},
+						Alerting: sloth.Alerting{
+							Name:        "",
+							Labels:      nil,
+							Annotations: nil,
+							PageAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+							TicketAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+						},
+					},
+				},
+			},
+			{
+				Version: sloth.Version,
+				Service: "bar",
+				Labels:  make(map[string]string),
+				SLOs: []sloth.SLO{
+					{
+						Name:        "availability",
+						Description: "availability SLO for bar service",
+						Objective:   95.0,
+						Labels:      make(map[string]string),
+						SLI: sloth.SLI{
+							Raw:    nil,
+							Events: nil,
+							Plugin: nil,
+						},
+						Alerting: sloth.Alerting{
+							Name:        "",
+							Labels:      nil,
+							Annotations: nil,
+							PageAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+							TicketAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+						},
+					},
+				},
+			},
+			{
+				Version: sloth.Version,
+				Service: "foobar",
+				Labels:  make(map[string]string),
+				SLOs: []sloth.SLO{
+					{
+						Name:        "availability",
+						Description: "availability SLO for foobar service",
+						Objective:   95.0,
+						Labels:      make(map[string]string),
+						SLI: sloth.SLI{
+							Raw:    nil,
+							Events: nil,
+							Plugin: nil,
+						},
+						Alerting: sloth.Alerting{
+							Name:        "",
+							Labels:      nil,
+							Annotations: nil,
+							PageAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+							TicketAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+						},
+					},
+					{
+						Name:        "correctness",
+						Description: "correctness SLO for foobar service",
+						Objective:   55.0,
+						Labels:      make(map[string]string),
+						SLI: sloth.SLI{
+							Raw:    nil,
+							Events: nil,
+							Plugin: nil,
+						},
+						Alerting: sloth.Alerting{
+							Name:        "",
+							Labels:      nil,
+							Annotations: nil,
+							PageAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+							TicketAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, exp := range expected {
+			actual, ok := resultSpec[exp.Service]
+			require.True(t, ok)
+			assert.Equal(t, exp, actual)
+		}
+	})
+
 	t.Run("Fail to parse the sloth spec SLO item if sloth annotation name for a given SLO is missing", func(t *testing.T) {
 		parser := NewParser(nil)
 		require.NoError(t, parser.parseSlothAnnotations(&ast.CommentGroup{List: []*ast.Comment{
@@ -380,7 +650,7 @@ func TestParseAnnotations(t *testing.T) {
 		assert.Len(t, (parser.specs["bar"].(*sloth.Spec)).SLOs, 0)
 	})
 
-	t.Run("Successfully parse duplicate Sloth service without overriding the original service", func(t *testing.T) {
+	t.Run("Successfully parse and merge duplicate Sloth service", func(t *testing.T) {
 		parser := NewParser(nil)
 		comments := []*ast.CommentGroup{
 			{List: []*ast.Comment{
@@ -426,6 +696,32 @@ func TestParseAnnotations(t *testing.T) {
 						Name:        "availability",
 						Description: "availability SLO for foobar service",
 						Objective:   95.0,
+						Labels:      make(map[string]string),
+						SLI: sloth.SLI{
+							Raw:    nil,
+							Events: nil,
+							Plugin: nil,
+						},
+						Alerting: sloth.Alerting{
+							Name:        "",
+							Labels:      nil,
+							Annotations: nil,
+							PageAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+							TicketAlert: sloth.Alert{
+								Disable:     false,
+								Labels:      nil,
+								Annotations: nil,
+							},
+						},
+					},
+					{
+						Name:        "foobar_availability",
+						Description: "availability SLO for foobar service",
+						Objective:   99.0,
 						Labels:      make(map[string]string),
 						SLI: sloth.SLI{
 							Raw:    nil,
@@ -494,11 +790,12 @@ func TestParseK8SAnnotations(t *testing.T) {
 					APIVersion: "sloth.slok.dev/v1",
 				},
 				ObjectMeta: v1.ObjectMeta{
-					Name: "foobar",
+					Name:   "foobar",
+					Labels: make(map[string]string),
 				},
 				Spec: k8sloth.PrometheusServiceLevelSpec{
 					Service: "foobar",
-					Labels:  nil,
+					Labels:  make(map[string]string),
 					SLOs: []k8sloth.SLO{
 						{
 							Name:        "availability",


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/slotalk/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes
* The fix should allow the parser to properly parse and generate SLO definitions for different specifications.
* The fix also tries to clean up the generate package.
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 🧪 Testing
- Unit tests.
- Manual testing:

1. Example monorepo project with multiple services and metrics. 

```shell
├── app1
│   ├── main.go
│   └── metrics.go
├── app2
│   ├── main.go
│   └── metrics.go
├── app3
│   ├── main.go
│   └── metrics.go
```

**app1/main.go**
```go
package app1

// @sloth service app1
```
**app1/metrics.go**
```go
package app1

// @sloth.slo name change_password_service_availability
// @sloth.slo objective 99.0
// @sloth.sli error_query sum(rate(tenant_failed_change_password_total[{{.window}}])) OR on() vector(0)
// @sloth.sli total_query sum(rate(tenant_change_password_total[{{.window}}]))
// @sloth.slo description SLO describing the availability of the Auth0 tenant change password service, setting the objective to 99%.
// @sloth.alerting name Auth0ChangePasswordAvailability
```
App2 and app3 follow a similar pattern.

2. Run sloscribe.

```shell
sloscribe init
```
This returns the following set of specifications.

```yaml
---
# Code generated by SLOsive's sloscribe CLI: https://github.com/tfadeyi/slosive.
# DO NOT EDIT.
version: prometheus/v1
service: app2
slos:
    - name: change_password_service_availability2
      description: SLO describing the availability of the Auth0 tenant change password service, setting the objective to 99%.
      objective: 99
      sli:
        events:
            error_query: sum(rate(tenant_failed_change_password_total[{{.window}}])) OR on() vector(0)
            total_query: sum(rate(tenant_change_password_total[{{.window}}]))
      alerting:
        name: Auth0ChangePasswordAvailability
---
# Code generated by SLOsive's sloscribe CLI: https://github.com/tfadeyi/slosive.
# DO NOT EDIT.
version: prometheus/v1
service: app3
slos:
    - name: change_password_service_availability3
      description: SLO describing the availability of the Auth0 tenant change password service, setting the objective to 99%.
      objective: 99
      sli:
        events:
            error_query: sum(rate(tenant_failed_change_password_total[{{.window}}])) OR on() vector(0)
            total_query: sum(rate(tenant_change_password_total[{{.window}}]))
      alerting:
        name: Auth0ChangePasswordAvailability
---
# Code generated by SLOsive's sloscribe CLI: https://github.com/tfadeyi/slosive.
# DO NOT EDIT.
version: prometheus/v1
service: app1
slos:
    - name: change_password_service_availability
      description: SLO describing the availability of the Auth0 tenant change password service, setting the objective to 99%.
      objective: 99
      sli:
        events:
            error_query: sum(rate(tenant_failed_change_password_total[{{.window}}])) OR on() vector(0)
            total_query: sum(rate(tenant_change_password_total[{{.window}}]))
      alerting:
        name: Auth0ChangePasswordAvailability
```
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- StackOverflow answer
- Related pull requests/issues from other repositories
-->


